### PR TITLE
Prevent stream from turning black

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
    "chunk_size": 4096,
    "gop_cache": false,
    "ping": 60,
-   "ping_timeout": 3
+   "ping_timeout": 30
  },
  "http": {
    "port": 8000,


### PR DESCRIPTION
In theory, with pinging every 3 sec there is a chance of detecting packet loss resulting in the stream temporarily disconnecting. Changing this to 30 sec will result in this scenario being very rare. 30 is the recommended amount on node-media server.